### PR TITLE
Fix a bug: tableToTopic mapping should be invalidated, rather than decreased.

### DIFF
--- a/src/main/java/de/uni_leipzig/informatik/asv/hdp/HDPGibbsSampler.java
+++ b/src/main/java/de/uni_leipzig/informatik/asv/hdp/HDPGibbsSampler.java
@@ -204,7 +204,7 @@ public class HDPGibbsSampler {
 		if (docState.wordCountByTable[table] == 0) { // table is removed
 			totalNumberOfTables--; 
 			numberOfTablesByTopic[k]--; 
-			docState.tableToTopic[table] --; 
+			docState.tableToTopic[table] = -1;
 		}
 	}
 	


### PR DESCRIPTION
   When removing an existing table, the mapping relation between table and topic should be invalidated, rather than being decreased as in line 207(HDPGibbsSampler.java). 

   This is a potential bug, though currently it doesn't affect the correctness of your code as you use <i>DOCState.wordCountByTable</i> to do defragment in line 351, better to fix it.
